### PR TITLE
Move platform dependency into tfm specific dependencies.

### DIFF
--- a/Sample/AspNetCore1.Test/project.json
+++ b/Sample/AspNetCore1.Test/project.json
@@ -1,9 +1,5 @@
 {
   "dependencies": {
-    "Microsoft.NETCore.App": {
-      "type": "platform",
-      "version": "1.0.0-rc2-*"
-    },
     "xunit": "2.1.0-rc2-*",
     "dotnet-test-xunit": "1.0.0-rc2-*",
     "AspNetCore1": "1.0.0"
@@ -13,7 +9,13 @@
       "imports": [
         "dotnet5.4",
         "portable-net451+win8"
-      ]
+      ],
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "version": "1.0.0-rc2-3002702",
+          "type": "platform"
+        }
+      }
     }
   },
   "testRunner": "xunit"

--- a/Sample/AspNetCore1/project.json
+++ b/Sample/AspNetCore1/project.json
@@ -5,10 +5,6 @@
   },
 
   "dependencies": {
-    "Microsoft.NETCore.App": {
-      "version": "1.0.0-rc2-3002702",
-      "type": "platform"
-    },
     "Microsoft.ApplicationInsights.AspNetCore": "1.0.0-rc2-final",
     "Microsoft.AspNetCore.Cors": "1.0.0-rc2-final",
     "Microsoft.AspNetCore.Diagnostics": "1.0.0-rc2-final",
@@ -27,7 +23,13 @@
       "imports": [
         "dotnet5.6",
         "dnxcore50"
-      ]
+      ],
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "version": "1.0.0-rc2-3002702",
+          "type": "platform"
+        }
+      }
     }
   },
 


### PR DESCRIPTION
`Microsoft.NETCore.App` is a platform specific meta-package and should be moved into TFM-specific dependencies for projects that can potentially target other TFMs (like ASP.NET Core apps).
See related discussion https://github.com/aspnet/Templates/issues/544
